### PR TITLE
Added ability to bind multiple swipe events

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -1,4 +1,9 @@
 /*
+* This is a fork of the touchSwipe jQuery plugin module.  The fork is maintained here:
+* https://github.com/Klortho/TouchSwipe-Jquery-Plugin.  The change was to allow multiple
+* event handlers to be bound to swipe events:
+* https://github.com/Klortho/TouchSwipe-Jquery-Plugin/commit/00bd371f2c0d154cf772a297d25c4008f1f84e96
+*
 * touchSwipe - jQuery Plugin
 * https://github.com/mattbryson/TouchSwipe-Jquery-Plugin
 * http://labs.skinkers.com/touchSwipe/


### PR DESCRIPTION
I wrote this up as issue #31 earlier today.  Here is my attempt.  I don't claim it is especially elegant, but it works.

You can bind multiple event handlers using the same calling convention as binding one:

```
$obj.swipe({swipe: myhandler1});
$obj.swipe({swipe: myhandler2});
```

Both will be called.  I went ahead and implemented this for all the events swipe, swipeLeft, swipeRight, swipeUp, swipeDown, swipeStatus, and click.  Only tested it for swipe, though.
