### PR TITLE
include form labels in the default list of excluded tags

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -200,7 +200,7 @@
 		triggerOnTouchLeave:false, 
 		allowPageScroll: "auto", 
 		fallbackToMouseEvents: true,	
-		excludedElements:"button, input, select, textarea, a, .noSwipe"
+		excludedElements:"label, button, input, select, textarea, a, .noSwipe"
 	};
 
 


### PR DESCRIPTION
In order to facilitate proper HTML form UI, labels should probably be included in the default exclusion list.
