### PR TITLE
Be more tolerant about the tap distance

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -1401,7 +1401,7 @@
 		 * @inner
 		*/
 		function validateTap() {
-		    return ((fingerCount === 1 || !SUPPORTS_TOUCH) && (isNaN(distance) || distance === 0));
+		    return ((fingerCount === 1 || !SUPPORTS_TOUCH) && (isNaN(distance) || distance < options.threshold));
 		}
 		
 		/**


### PR DESCRIPTION
I have found that the tap validation is being too strict in many cases, as a move of just a few pixels will invalidate the event. On certain platforms and touch screens especially, (Windows with Chrome in my case) it is hard to always tap with a zero distance. While on iOS devices it seems to occur less frequently. For a user who is unaware of this issue though, it quickly gets irritating when taps are ignored and nothing is happening.

The solution that worked for me, was to use the swipe threshold as an upper limit for the distance. Alternatively there could be an additional tap option for this, but I am not sure why there has to be a gap between the tap and swipe.
