### PR TITLE
Detect if the swipe is valid at the end of the touch event.

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -740,7 +740,7 @@
 			duration = calculateDuration();
 			
 			//If we trigger handlers at end of swipe OR, we trigger during, but they didnt trigger and we are still in the move phase
-			if(didSwipeBackToCancel()) {
+			if(didSwipeBackToCancel() || !validateSwipeDistance()) {
 			    phase = PHASE_CANCEL;
                 triggerHandler(event, phase);
 			} else if (options.triggerOnTouchEnd || (options.triggerOnTouchEnd == false && phase === PHASE_MOVE)) {


### PR DESCRIPTION
Fix for Issue #130

Noticed that when a touch event ends it was not setting the phase to cancel when the threshold was not met.

This is shown in the demo /demos/Thresholds.html where the text "You didnt swipe far enough" was not being displayed.
