### PR TITLE
Fingers param is not respected on non-touch devices

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -155,7 +155,7 @@
 	* You can set the default values by updating any of the properties prior to instantiation.
 	* @name $.fn.swipe.defaults
 	* @namespace
-	* @property {int} [fingers=1] The number of fingers to detect in a swipe. Any swipes that do not meet this requirement will NOT trigger swipe handlers.
+	* @property {int} [fingers='all'] The number of fingers to detect in a swipe. Any swipes that do not meet this requirement will NOT trigger swipe handlers.
 	* @property {int} [threshold=75] The number of pixels that the user must move their finger by before it is considered a swipe. 
 	* @property {int} [cancelThreshold=null] The number of pixels that the user must move their finger back from the original swipe direction to cancel the gesture.
 	* @property {int} [pinchThreshold=20] The number of pixels that the user must pinch their finger by before it is considered a pinch. 
@@ -187,7 +187,7 @@
 	
 	*/
 	var defaults = {
-		fingers: 1, 		
+		fingers: ALL_FINGERS, 		
 		threshold: 75, 	
 		cancelThreshold:null,	
 		pinchThreshold:20,

--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -556,7 +556,7 @@
 
 			
 			// check the number of fingers is what we are looking for, or we are capturing pinches
-			if (!SUPPORTS_TOUCH || (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || hasPinches()) {
+			if ( (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || hasPinches() ) {
 				// get the coordinates of the touch
 				createFingerData( 0, evt );
 				startTime = getTimeStamp();
@@ -646,7 +646,7 @@
 			}
 			
 			
-			if ( (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || !SUPPORTS_TOUCH || hasPinches() ) {
+			if ( (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || hasPinches() ) {
 				
 				direction = calculateDirection(currentFinger.start, currentFinger.end);
 				


### PR DESCRIPTION
The code below should not execute on non-touch devices because fingerCount == 0 but it does.

```javascript
$("#fingers").swipe({
  swipe:function(event, direction, distance, duration, fingerCount){
    $(this).text("You swiped " + direction + " with " + fingerCount + " fingers" );
  },
  fingers:1
});
```

Removing !SUPPORTS_TOUCH from conditions for touchStart and touchMove to make sure the other conditions are respected.