### PR TITLE
Separate license/changelog comment

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -10,6 +10,9 @@
 * Copyright (c) 2010 Matt Bryson
 * Dual licensed under the MIT or GPL Version 2 licenses.
 *
+*/
+
+/*
 *
 * Changelog
 * $Date: 2010-12-12 (Wed, 12 Dec 2010) $


### PR DESCRIPTION
We use the non-min file in dev (helps with debugging).  Our uglifier still prints out all license comments in prod. Would be helpful to break these out.

Great project!
<3z
-Tom
