### PR TITLE
Only prevent default event handling on valid swipe

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -729,10 +729,7 @@
 			if(inMultiFingerRelease()) {	
 				fingerCount=previousTouchFingerCount;
 			}	
-				 
-			//call this on jq event so we are cross browser 
-			jqEvent.preventDefault(); 
-			
+		
 			//Set end of swipe
 			endTime = getTimeStamp();
 			
@@ -740,10 +737,12 @@
 			duration = calculateDuration();
 			
 			//If we trigger handlers at end of swipe OR, we trigger during, but they didnt trigger and we are still in the move phase
-			if(didSwipeBackToCancel()) {
+			if(didSwipeBackToCancel() || !validateSwipeDistance()) {
 			    phase = PHASE_CANCEL;
                 triggerHandler(event, phase);
 			} else if (options.triggerOnTouchEnd || (options.triggerOnTouchEnd == false && phase === PHASE_MOVE)) {
+				//call this on jq event so we are cross browser 
+				jqEvent.preventDefault(); 
 				phase = PHASE_END;
                 triggerHandler(event, phase);
 			}


### PR DESCRIPTION
In addition to pull request: "https://github.com/mattbryson/TouchSwipe-Jquery-Plugin/pull/131" this commit prevents that events won't be triggered on invalid / canceled swipes.
