### PR TITLE
Use JQ event if original event does not exist

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -747,7 +747,8 @@
 		*/
 		function touchEnd(jqEvent) {
 			//As we use Jquery bind for events, we need to target the original event object
-			var event = jqEvent.originalEvent;
+			//If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
+			var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
 				
 
 			//If we are still in a touch with another finger return
@@ -829,7 +830,8 @@
 		* @inner
 		*/
 		function touchLeave(jqEvent) {
-			var event = jqEvent.originalEvent;
+			//If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
+			var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
 			
 			//If we have the trigger on leave property set....
 			if(options.triggerOnTouchLeave) {


### PR DESCRIPTION
This commit updates the `touchEnd` and `touchLeave` functions to use
the jQuery event object if no originalEvent property exists.

This makes it possible to trigger the events programatically in browser tests.

A similar change was made to `touchStart` and `touchMove` in 038de2a4eb5dda46f0d8facc052eb910a31ffb93
to resolve issues reported in issue #72.