### PR TITLE
Support 10 elements in fingerData and initialize identifiers correctly

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -1622,11 +1622,11 @@
 		*/
 		function createAllFingerData() {
 			var fingerData=[];
-			for (var i=0; i<=5; i++) {
+			for (var i=0; i<=10; i++) {
 				fingerData.push({
 					start:{ x: 0, y: 0 },
 					end:{ x: 0, y: 0 },
-					identifier:0
+					identifier:i
 				});
 			}
 			


### PR DESCRIPTION
I found a bug in jquery.touchSwipe.js

The bug resulted in a NPE at line 1596 (i.e. f.end.x = evt.pageX||evt.clientX;)
This was happening because touchMove calls getFingerData for an identifier that does not exist - this is because createAllFingerData was setting the identifier of all elements to 0 and not i

Additionally the code only supported identifiers 0 to 5 but this should probably be 0 to 10 to cover the case that a device supports 10 concurrent touch events (one per finger!)
