### PR TITLE
Stopped swipes and touches from being mutually exclusive to fix https…

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -940,25 +940,24 @@
 					//Trigger the pinch events...
 					ret = triggerHandlerForGesture(event, phase, PINCH);
 				}
-			} else {
+			} 
 			 
-				// CLICK / TAP (if the above didn't cancel)
-				if(didDoubleTap() && ret!==false) {
-					//Trigger the tap events...
-					ret = triggerHandlerForGesture(event, phase, DOUBLE_TAP);
-				}
-				
-				// CLICK / TAP (if the above didn't cancel)
-				else if(didLongTap() && ret!==false) {
-					//Trigger the tap events...
-					ret = triggerHandlerForGesture(event, phase, LONG_TAP);
-				}
+			// CLICK / TAP (if the above didn't cancel)
+			if(didDoubleTap() && ret!==false) {
+				//Trigger the tap events...
+				ret = triggerHandlerForGesture(event, phase, DOUBLE_TAP);
+			}
+			
+			// CLICK / TAP (if the above didn't cancel)
+			else if(didLongTap() && ret!==false) {
+				//Trigger the tap events...
+				ret = triggerHandlerForGesture(event, phase, LONG_TAP);
+			}
 
-				// CLICK / TAP (if the above didn't cancel)
-				else if(didTap() && ret!==false) {
-					//Trigger the tap event..
-					ret = triggerHandlerForGesture(event, phase, TAP);
-				}
+			// CLICK / TAP (if the above didn't cancel)
+			else if(didTap() && ret!==false) {
+				//Trigger the tap event..
+				ret = triggerHandlerForGesture(event, phase, TAP);
 			}
 			
 			


### PR DESCRIPTION
…://github.com/mattbryson/TouchSwipe-Jquery-Plugin/issues/248

Hi there,

I found that swipe gestures and tap / hold gestures seemed to be mutually exclusive, and tracked the reason for this down to an if-else block at line 943.

I believe that the code looks as though the "else" portion dealing with the tap / hold gestures did actually expect the swipes and the holds to be able to work together, because they're testing a value "ret" that could have only be set within the "if" part that was dealing with the swipes.

Many thanks,
Duncan